### PR TITLE
feat (or fix): handle multiple instances

### DIFF
--- a/src/bag.manager.spec.ts
+++ b/src/bag.manager.spec.ts
@@ -3,6 +3,38 @@ import {CreateBagManager, GetBagManager} from "./bag.manager";
 import {Bag} from "./saddlebag";
 
 describe('bag manager basics', () => {
+    it('should create multiple instances of the same bag', () => {
+      const bagKey = 'bag-key';
+
+      const changeKey = 'changed-key';
+
+      let allChangesCounter = 0;
+      let subscriptionCounter = 0;
+
+      const createInstance = () => {
+        let bm = CreateBagManager(true);
+        let bag = bm.createBag(bagKey)!;
+
+        bag.onAllChanges(() => {
+          allChangesCounter++;
+        });
+
+        bag.subscribe(changeKey, () => {
+          subscriptionCounter++;
+        });
+      };
+
+      createInstance();
+      createInstance();
+      createInstance();
+
+      let bm = CreateBagManager(true);
+      let bag = bm.createBag(bagKey)!;
+      bag.set(changeKey, 'ok');
+
+      expect(allChangesCounter).toEqual(3);
+      expect(subscriptionCounter).toEqual(3);
+    });
 
     it('create a new bag manager and a bag', () => {
 
@@ -13,6 +45,8 @@ describe('bag manager basics', () => {
         expect(bag.get('foo')).toBeUndefined();
         bag.set('foo', 'bar');
         expect(bag.get('foo')).toEqual('bar');
+
+        bag?.reset()
     })
 
     it('ensure two bad managers always have the same bag', () => {

--- a/src/bag.manager.ts
+++ b/src/bag.manager.ts
@@ -101,6 +101,10 @@ class saddlebagManager implements BagManager {
     }
 
     createBag<T>(key: string): Bag<T> {
+        if (this._bags.has(key)) {
+          return this._bags.get(key)!;
+        }
+
         const bag: Bag<T> = CreateBag<T>(key, this._stateful);
         bag.db = this._db;
         this._bags.set(key, bag);


### PR DESCRIPTION
Using saddlebag in my personal project, I wanted to have multiple instances of a bag so that each instance could be synced up with the same data.
| Behavior Before | Behavior After |
|--------|--------|
| Only the most recently created instance was synced with the data because it overwrote all of the old ones | All instances of the same bag synced with same data |
| https://github.com/user-attachments/assets/4132e1fd-7a16-48bd-ab5b-955029e76c40 | https://github.com/user-attachments/assets/487fd1c7-be85-4b89-afd0-4c4ab98f7dc1 |